### PR TITLE
Implement multiple reports per message

### DIFF
--- a/rbforwarder.go
+++ b/rbforwarder.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/oleiade/lane"
 	"github.com/redBorder/rbforwarder/types"
 )
 
@@ -91,10 +92,12 @@ func (f *RBForwarder) Produce(buf []byte, options map[string]interface{}) error 
 
 	message := &message{
 		seq:  seq,
-		opts: options,
+		opts: lane.NewStack(),
 	}
 
 	message.PushData(buf)
+	message.opts.Push(options)
+
 	f.p.input <- message
 
 	return nil

--- a/types/messenger.go
+++ b/types/messenger.go
@@ -4,5 +4,4 @@ package types
 type Messenger interface {
 	PopData() ([]byte, error)
 	PushData(data []byte)
-	GetOpt(name string) interface{}
 }


### PR DESCRIPTION
Allows for a message to have multiples reports. This can be useful if you want to merge multiple messages in a single one keeping all the reports.

---

Closes #11
